### PR TITLE
Update rescue to capture new error when database doesn't exist

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -51,6 +51,8 @@ module PublicActivity
           end
         rescue ::ActiveRecord::NoDatabaseError
           warn("[WARN] database doesn't exist. Skipping PublicActivity::Activity#parameters's serialization")
+        rescue ::ActiveRecord::ConnectionNotEstablished
+          warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")
         rescue ::PG::ConnectionBad
           warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")
         rescue Mysql2::Error::ConnectionError


### PR DESCRIPTION
As of rails 6.1 if the db doesn't exist the error thown changed to `ActiveRecord::ConnectionNotEstablished`.  This gem needs to catch this so the app can still initialize(and db migrations can run).